### PR TITLE
Fixed error when saving plugin config

### DIFF
--- a/addons/godot_data_editor/options.gd
+++ b/addons/godot_data_editor/options.gd
@@ -130,7 +130,7 @@ func _on_Options_confirmed():
 		config.set_value("custom", "serializer", serializer)
 		config.set_value("custom", "encrypt", encrypt)
 		config.set_value("custom", "password", password)
-		config.set_value("custom", "class_directory", output_directory)		
+		config.set_value("custom", "class_directory", class_directory)		
 		config.set_value("custom", "output_directory", output_directory)		
 		config.set_value("custom", "sanitize_ids", sanitize_ids)	
 		config.save("res://addons/godot_data_editor/plugin.cfg")


### PR DESCRIPTION
Hello!

First of all, I gotta say I love your plugin! Stumbling upon it by chance saved me a lot of time writing a similar data storage solution for my own project.

This PR simply fixes an error I stumbled upon when saving the config from the editor, as the reference for the data output directory was repeated in the class directory line.